### PR TITLE
Added route protection

### DIFF
--- a/backend/flask_api/blueprints/skills/views.py
+++ b/backend/flask_api/blueprints/skills/views.py
@@ -6,10 +6,18 @@ from models.skill import Skill
 skills_api_blueprint = Blueprint('skills_api', __name__)
 
 @skills_api_blueprint.route('/create', methods=['POST'])
+@jwt_required
 def create():
     # Check for valid json
     if not request.is_json:
         return error_401("Reponse is not JSON")
+    
+    # Check if user exists and signed in
+    jwt_user = get_jwt_identity()
+    user = User.get_or_none(User.name == jwt_user) 
+
+    if not user:
+        return error_401("Unauthorized action")
     
     # Retrieve data from json
     data = request.get_json()


### PR DESCRIPTION
Hi there!

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for missing JSON Web Tokens (JWTs).

This generally comes up when a project is using `flask_jwt_extended` and has routes that aren't protected with the `@jwt_required` decorator. I noticed that you had the authentication decorator on other /create routes in your project, so I added the route protection in case it was just missing.

Bento flagged a couple of other actionables within your codebase, but I wanted to keep the PR short. If you are curious, feel free download and give Bento a try! (https://bento.dev)